### PR TITLE
.DS_Store added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/*.m*
 *.orig
 
 *.DS_Store
+.DS_Store
+DS_Store


### PR DESCRIPTION
I've added ".DS_Store" to the .gitignore file to prevent cluttering the repository with these files while developing on a Mac OS X system.

.DS_Store contains informations about all display settings for a folder being shown in Finder - Mac OS X's file manager - and is per se irrelevant for this project.
