### PR TITLE
Fix access violation in monodevelop 5.2

### DIFF
--- a/MonoDevelop.DBinding/Gui/DModuleOutlineExtension.cs
+++ b/MonoDevelop.DBinding/Gui/DModuleOutlineExtension.cs
@@ -177,7 +177,8 @@ namespace MonoDevelop.D.Gui
 
 			if (id != null)
 			{
-				using (var img = ImageService.GetIcon(id))
+				var img = ImageService.GetIcon(id);
+				if (img != null)
 					pixRenderer.Pixbuf = img.ToPixbuf(IconSize.Menu);
 			}
 		}


### PR DESCRIPTION
The error was 

`Attempted to read or write protected memory. This is often an indication that other memory is corrupt.`

   at Gdk.CairoHelper.gdk_cairo_set_source_pixbuf(IntPtr cr, IntPtr pixbuf, Double pixbuf_x, Double pixbuf_y)
   at Gdk.CairoHelper.SetSourcePixbuf(Context cr, Pixbuf pixbuf, Double pixbuf_x, Double pixbuf_y)
   at Xwt.GtkBackend.GtkImage.DrawPixbuf(Context ctx, Pixbuf img, Double x, Double y, ImageDescription idesc)
   at Xwt.GtkBackend.GtkImage.Draw(ApplicationContext actx, Context ctx, Double scaleFactor, Double x, Double y, ImageDescription idesc)
   at Xwt.GtkBackend.GtkImage.RenderFrame(ApplicationContext actx, Double scaleFactor, Double width, Double height)
   at Xwt.GtkBackend.GtkImage.GetBestFrame(ApplicationContext actx, Double scaleFactor, Double width, Double height, Boolean forceExactSize)
   at Xwt.GtkBackend.GtkImage.ToPixbuf(ApplicationContext actx, Double width, Double height)
   at Xwt.GtkBackend.GtkEngine.GetNativeImage(Image image)
   at Xwt.Toolkit.GetNativeImage(Image image)
   at MonoDevelop.Components.GtkUtil.ToPixbuf(Image image, IconSize size)
   at MonoDevelop.D.Gui.DModuleOutlineExtension.OutlineTreeIconFunc(TreeViewColumn column, CellRenderer cell, TreeModel model, TreeIter iter) in e:\include\Mono-D\MonoDevelop.DBinding\Gui\DModuleOutlineExtension.cs:line 181
   at GtkSharp.TreeCellDataFuncWrapper.NativeCallback(IntPtr tree_column, IntPtr cell, IntPtr tree_model, IntPtr iter, IntPtr data)
   at Gtk.Application.gtk_main()
   at Gtk.Application.Run()
   at MonoDevelop.Ide.IdeApp.Run()
   at MonoDevelop.Ide.IdeStartup.Run(MonoDevelopOptions options)
   at MonoDevelop.Ide.IdeStartup.Main(String[] args, IdeCustomizer customizer)
   at Xamarin.Startup.MainClass.Main(String[] args)
