### PR TITLE
Fix highlighting for character literals

### DIFF
--- a/MonoDevelop.DBinding/DSyntaxHighlightingMode.xml
+++ b/MonoDevelop.DBinding/DSyntaxHighlightingMode.xml
@@ -48,7 +48,7 @@
 		<End>`</End>
 	</Span>
 
-	<Span color = "String" rule="String" stopateol = "true" escape="\'">
+	<Span color = "String" rule="String" stopateol = "true" escape="\'|\\">
 		<Begin>&apos;</Begin>
 		<End>&apos;</End>
 	</Span>


### PR DESCRIPTION
Character literal with quotation mark inside breaks the highlighting. Changing escape string to `\'|\\` fixes it. (escape string for double-quoted strings is `\"|\\`)

Before:
![ggmacwk5r](https://cloud.githubusercontent.com/assets/1284655/7295620/0e0156e2-e9e2-11e4-95a5-7c42dda79c71.png)

After:
![image](https://cloud.githubusercontent.com/assets/1284655/7295648/5d900dac-e9e2-11e4-9f7f-336feb3dec9f.png)

Not sure why `\\` is necessary to process `"` correctly though.
I also tried `escape='\'` as it's done in [C++ syntax mode](https://github.com/mono/monodevelop/blob/master/main/src/core/Mono.Texteditor/SyntaxModes/CPPSyntaxMode.xml#L54) but it gives incurrect result.