### PR TITLE
Fix detection of Mac OS X. #616

### DIFF
--- a/MonoDevelop.DBinding/Building/DCompilerService.cs
+++ b/MonoDevelop.DBinding/Building/DCompilerService.cs
@@ -356,7 +356,14 @@ namespace MonoDevelop.D.Building
 		}
 		
 		public static bool IsMac {
-			get{ return Environment.OSVersion.Platform == PlatformID.MacOSX;}	
+			get {
+				if(Environment.OSVersion.Platform != PlatformID.Unix)
+					return false;
+
+				Mono.Unix.Native.Utsname results;
+				Mono.Unix.Native.Syscall.uname(out results);
+				return results.sysname == "Darwin";
+			}
 		}
 		
 		public static bool IsLinux {


### PR DESCRIPTION
reference to Mono.Posix.dll must be added to the project. The file must be copied to the Mono-D distribution (./ext/Mono.Posix.dll), because it is not present on the Windows distribution of Xamarin Studio.
Mono.Posix.dll can be found here:
/Applications/Xamarin Studio.app/Contents/Resources/lib/monodevelop/AddIns/Xamarin.Sketches/XamarinInteractiveAgentsMac.app/Contents/MonoBundle/Mono.Posix.dll

The initial check for Unix will prevent the posix code from trying to run on windows.